### PR TITLE
Note version tracking

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,11 @@
   "name": "arholiac",
   "dependencies": {
     "angular": "^1.6.4",
+    "angular-animate": "^1.6.6",
+    "angular-bootstrap": "^2.5.0",
     "angular-resource": "^1.6.4",
     "angular-route": "^1.6.4",
+    "angular-sanitize": "^1.6.6",
     "bootstrap": "^3.3.7",
     "lodash": "^4.17.4"
   },

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -3,4 +3,7 @@
 angular.module('app', [
     'ngResource',
     'ngRoute',
+    'ngAnimate',
+    'ngSanitize',
+    'ui.bootstrap',
 ]);

--- a/public/src/note/detail.html
+++ b/public/src/note/detail.html
@@ -3,11 +3,24 @@
 <ol class="breadcrumb">
     <li><a href="#!/">List</a></li>
     <li class="active" ng-bind="$ctrl.note.subject"></li>
+    <li class="active">Version {{$ctrl.note.version}}</li>
 </ol>
 
-<p class="clearfix">
-    <a class="btn btn-default pull-right" ng-href="#!/notes/{{ $ctrl.note.id }}/edit">Edit</a>
-</p>
+<a class="btn btn-default" ng-href="#!/notes/{{ $ctrl.note.id }}/edit">Edit</a>
+<div ng-if="$ctrl.hasVersions" class="btn-group" uib-dropdown is-open="$ctrl.isopen">
+    <button id="single-button" type="button" class="btn btn-primary" uib-dropdown-toggle ng-disabled="disabled">
+        Previous Versions <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button">
+        <li ng-repeat="version in $ctrl.notehistory">
+            <a ng-click="$ctrl.loadVersion(version)" href>
+                <span class="glyphicon glyphicon-time" aria-hidden="true"></span> View version {{version.version}}
+            </a>
+        </li>
+        <li class="divider"></li>
+        <li><a ng-href="#!/notes/{{ $ctrl.note.id }}">Latest Version</a></li>
+    </ul>
+</div>
 
 <div class="panel panel-default">
     <div class="panel-heading">
@@ -17,4 +30,17 @@
     <div class="panel-body" style="white-space: pre-wrap;" ng-bind="$ctrl.note.body"></div>
 
     <div class="panel-footer" ng-bind="$ctrl.note.updatedAt | date:'medium'"></div>
+</div>
+
+<div ng-if="$ctrl.showHistory">
+    <a class="btn btn-default" ng-click="$ctrl.showHistory = false">Hide</a>
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{$ctrl.historicalSubject}}</h3>
+        </div>
+
+        <div class="panel-body" style="white-space: pre-wrap;">{{$ctrl.historicalBody}}</div>
+
+        <div class="panel-footer">Version {{$ctrl.historicalVersion}}</div>
+    </div>
 </div>

--- a/public/src/note/detail.js
+++ b/public/src/note/detail.js
@@ -5,5 +5,32 @@ angular.module('app').component('noteDetail', {
     bindings: {
         session: '<',
         note: '<',
+        notehistory: '<',
+        historicalSubject: '@',
+        historicalBody: '@',
+        historicalVersion: '@',
+    },
+    controller: function() {
+        this.$onInit = function() {
+            this.hasVersions = !_.isEmpty(this.notehistory);
+            this.showHistory = false;
+        };
+
+        this.status = {
+            isopen: false
+        };
+
+        this.toggleDropdown = function($event) {
+            $event.preventDefault();
+            $event.stopPropagation();
+            this.status.isopen = !this.status.isopen;
+        };
+
+        this.loadVersion = function(notehistory) {
+            this.historicalSubject = notehistory.subject;
+            this.historicalBody = notehistory.body;
+            this.historicalVersion = notehistory.version;
+            this.showHistory = true;
+        }
     },
 });

--- a/public/src/note/edit.html
+++ b/public/src/note/edit.html
@@ -3,6 +3,7 @@
 <ol class="breadcrumb">
     <li><a href="#!/">List</a></li>
     <li><a ng-href="#!/notes/{{ $ctrl.note.id }}" ng-bind="$ctrl.note.subject"></a></li>
+    <li class="active">Version {{$ctrl.note.version}}</li>
     <li class="active">Edit</li>
 </ol>
 

--- a/public/src/note/edit.js
+++ b/public/src/note/edit.js
@@ -5,12 +5,26 @@ angular.module('app').component('noteEdit', {
     bindings: {
         session: '<',
         note: '<',
+        notehistory: '@',
     },
-    controller: function(Note, $location) {
+    controller: function(Note, NoteHistory, $location) {
+        this.$onInit = function() {
+            this.notehistory = this.note.body;
+        };
+
         this.updateNote = function() {
             this.error = this._validate();
 
             if (!this.error) {
+                NoteHistory.save({
+                    id: this.note.id,
+                    note: {
+                        subject: this.note.subject,
+                        body: this.notehistory,
+                        version: this.note.version
+                    }
+                });
+
                 Note.update({
                     id: this.note.id
                 }, {

--- a/public/src/note/list.html
+++ b/public/src/note/list.html
@@ -14,6 +14,7 @@
     <tr>
         <th>Subject</th>
         <th>Updated at</th>
+        <th>Version</th>
         <th></th>
     </tr>
 
@@ -23,6 +24,8 @@
         </td>
 
         <td ng-bind="note.updatedAt | date:'medium'"></td>
+
+        <td ng-bind="note.version"></td>
 
         <td>
             <a href="" ng-click="$ctrl.deleteNote(note)">

--- a/public/src/resources/noteHistory.js
+++ b/public/src/resources/noteHistory.js
@@ -1,5 +1,5 @@
 'use strict';
 
 angular.module('app').factory('NoteHistory', function($resource) {
-    return $resource('/api/noteHistory', {}, {});
+    return $resource('/api/noteHistory/:id', {}, {});
 });

--- a/public/src/resources/noteHistory.js
+++ b/public/src/resources/noteHistory.js
@@ -1,0 +1,5 @@
+'use strict';
+
+angular.module('app').factory('NoteHistory', function($resource) {
+    return $resource('/api/noteHistory', {}, {});
+});

--- a/public/src/routes.js
+++ b/public/src/routes.js
@@ -31,12 +31,15 @@ angular.module('app').config(function($routeProvider) {
     };
 
     const noteDetailPage = {
-        template: '<note-detail session="$resolve.session" note="$resolve.note"></note-detail>',
+        template: '<note-detail session="$resolve.session" note="$resolve.note" notehistory="$resolve.notehistory"></note-detail>',
         resolve: {
             session: Session => Session.current().$promise,
             note: (Note, $route) => Note.get({
                 id: $route.current.params.noteId
-            }).$promise
+            }).$promise,
+            notehistory: (NoteHistory, $route) => NoteHistory.query({
+                id: $route.current.params.noteId
+            }).$promise,
         }
     };
 
@@ -46,7 +49,7 @@ angular.module('app').config(function($routeProvider) {
             session: Session => Session.current().$promise,
             note: (Note, $route) => Note.get({
                 id: $route.current.params.noteId
-            }).$promise
+            }).$promise,
         }
     };
 

--- a/src/api/route/noteHistory.js
+++ b/src/api/route/noteHistory.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const domain = require('../../domain');
+
+module.exports.create = (req, res) => {
+    const id = req.body.id;
+    const reqNote = req.body.note;
+
+    return domain.Note.getById(id).then(note => {
+        return note.createNoteHistory(reqNote).then(noteHistory => {
+            res.json(noteHistory.expose());
+        });
+
+    });
+};

--- a/src/api/route/noteHistory.js
+++ b/src/api/route/noteHistory.js
@@ -1,6 +1,13 @@
 'use strict';
 
 const domain = require('../../domain');
+const _ = require('lodash');
+
+module.exports.list = (req, res) => {
+    return req.note.noteHistory().then(noteHistory => {
+        res.json(_.invokeMap(noteHistory, 'expose'));
+    });
+};
 
 module.exports.create = (req, res) => {
     const id = req.body.id;
@@ -10,6 +17,5 @@ module.exports.create = (req, res) => {
         return note.createNoteHistory(reqNote).then(noteHistory => {
             res.json(noteHistory.expose());
         });
-
     });
 };

--- a/src/api/router/index.js
+++ b/src/api/router/index.js
@@ -52,6 +52,10 @@ function setupRoutesWithRequiredAuthentication(router) {
     );
 
     // NoteHistory
+    router.get(
+        '/noteHistory/:noteId',
+        route.noteHistory.list
+    );
     router.post(
         '/noteHistory',
         apiMiddleware.jsonParser,

--- a/src/api/router/index.js
+++ b/src/api/router/index.js
@@ -50,6 +50,13 @@ function setupRoutesWithRequiredAuthentication(router) {
         '/notes/:noteId',
         route.note.delete
     );
+
+    // NoteHistory
+    router.post(
+        '/noteHistory',
+        apiMiddleware.jsonParser,
+        route.noteHistory.create
+    );
 }
 
 function setup(router) {

--- a/src/app/views/index.html
+++ b/src/app/views/index.html
@@ -15,8 +15,11 @@
 
         <script type="text/javascript" src="/lib/lodash/lodash.js"></script>
         <script type="text/javascript" src="/lib/angular/angular.js"></script>
+        <script type="text/javascript" src="/lib/angular-animate/angular-animate.js"></script>
+        <script type="text/javascript" src="/lib/angular-bootstrap/ui-bootstrap-tpls.js"></script>
         <script type="text/javascript" src="/lib/angular-resource/angular-resource.js"></script>
         <script type="text/javascript" src="/lib/angular-route/angular-route.js"></script>
+        <script type="text/javascript" src="/lib/angular-sanitize/angular-sanitize.js"></script>
         <script type="text/javascript" src="/dist/app.js"></script>
     </body>
 </html>

--- a/src/domain/error.js
+++ b/src/domain/error.js
@@ -21,6 +21,7 @@ DomainError.Code = _.extend(_.transform([
 }), _.transform([
     'USER_NOT_FOUND',
     'NOTE_NOT_FOUND',
+    'NOTEHISTORY_NOT_FOUND',
 ], (result, code) => {
     result[code] = {
         name: code,

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const _ = require('lodash');
+const q = require('q');
+const model = require('../model');
+const domain = require('../domain');
 
 class Note {
     constructor(note) {
@@ -25,6 +28,12 @@ class Note {
         ]);
     }
 
+    createNoteHistory(note) {
+        return this._note.createVersion(note).then(modelNoteHistory => {
+            return new domain.NoteHistory(modelNoteHistory);
+        });
+    }
+
     update(note) {
         return this._note.update(note, {
             hooks: true
@@ -33,6 +42,21 @@ class Note {
 
     delete() {
         return this._note.destroy();
+    }
+
+    static getById(id) {
+        return model.Note.findOne({
+            where: {
+                id
+            }
+        }).then(modelNote => {
+            if (!modelNote) {
+                return q.reject(new domain.Error(domain.Error.Code.NOTE_NOT_FOUND));
+            }
+            else {
+                return new Note(modelNote);
+            }
+        });
     }
 }
 

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -11,17 +11,24 @@ class Note {
         return this._note.id;
     }
 
+    get version() {
+        return this._note.version;
+    }
+
     expose() {
         return _.pick(this._note, [
             'id',
             'subject',
             'body',
+            'version',
             'updatedAt',
         ]);
     }
 
     update(note) {
-        return this._note.update(note);
+        return this._note.update(note, {
+            hooks: true
+        });
     }
 
     delete() {

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -28,6 +28,16 @@ class Note {
         ]);
     }
 
+    noteHistory() {
+        return this._note.getVersions({
+            order: [['version', 'ASC']],
+        }).then(versions => {
+            return _.map(versions, noteHistory => {
+                return new domain.NoteHistory(noteHistory);
+            });
+        });
+    }
+
     createNoteHistory(note) {
         return this._note.createVersion(note).then(modelNoteHistory => {
             return new domain.NoteHistory(modelNoteHistory);

--- a/src/domain/noteHistory.js
+++ b/src/domain/noteHistory.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const _ = require('lodash');
+
+class NoteHistory {
+    constructor(note) {
+        this._noteHistory = note;
+    }
+
+    get id() {
+        return this._noteHistory.id;
+    }
+
+    get version() {
+        return this._noteHistory.version;
+    }
+
+    expose() {
+        return _.pick(this._noteHistory, [
+            'id',
+            'subject',
+            'body',
+            'version',
+            'updatedAt',
+        ]);
+    }
+
+    update(noteHistory) {
+        return this._noteHistory.update(noteHistory);
+    }
+
+    delete() {
+        return this._noteHistory.destroy();
+    }
+}
+
+module.exports = NoteHistory;

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -8,14 +8,18 @@ const sequelize = new Sequelize(config.postgresql.url, {
 
 const User = require('./user');
 const Note = require('./note');
+const NoteHistory = require('./noteHistory');
 const userNoteAssociation = require('./userNote');
+const noteNoteHistoryAssociation = require('./noteNoteHistory');
 
 const models = {
     sequelize,
     User: User.define(sequelize),
     Note: Note.define(sequelize),
+    NoteHistory: NoteHistory.define(sequelize),
 };
 
 userNoteAssociation.define(models);
+noteNoteHistoryAssociation.define(models);
 
 module.exports = models;

--- a/src/model/note.js
+++ b/src/model/note.js
@@ -24,6 +24,11 @@ module.exports.define = sequelize => {
                 notEmpty: true
             }
         },
+        version: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            defaultValue: 1,
+        }
     }, {
         indexes: [
             {
@@ -32,5 +37,10 @@ module.exports.define = sequelize => {
                 fields: ['userId', 'id']
             },
         ],
+        hooks: {
+            beforeUpdate: (note, option) => {
+                note.version = note.version + 1;
+            },
+        },
     });
 };

--- a/src/model/noteHistory.js
+++ b/src/model/noteHistory.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Sequelize = require('sequelize');
+
+module.exports.define = sequelize => {
+    return sequelize.define('NoteHistory', {
+        id: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        subject: {
+            type: Sequelize.STRING,
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }
+        },
+        body: {
+            type: Sequelize.TEXT,
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }
+        },
+        version: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+        }
+    }, {
+        indexes: [
+            {
+                name: 'NotesHistory_notes_id',
+                unique: true,
+                fields: ['noteId', 'id']
+            },
+        ],
+    });
+};

--- a/src/model/noteNoteHistory.js
+++ b/src/model/noteNoteHistory.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports.define = models => {
+    models.Note.hasMany(models.NoteHistory, {
+        foreignKey: {
+            name: 'noteId',
+            allowNull: false
+        },
+        as: 'versions',
+        onUpdate: 'RESTRICT',
+        onDelete: 'CASCADE'
+    });
+};

--- a/test/api/router.test.js
+++ b/test/api/router.test.js
@@ -39,8 +39,8 @@ describe('Tests for api router', function() {
         });
 
         it('should setup the router', function() {
-            router.get.callCount.should.equal(3);
-            router.post.callCount.should.equal(2);
+            router.get.callCount.should.equal(4);
+            router.post.callCount.should.equal(3);
             router.put.callCount.should.equal(1);
             router.delete.callCount.should.equal(2);
             router.use.callCount.should.equal(2);
@@ -94,6 +94,17 @@ describe('Tests for api router', function() {
             router.delete.calledWithExactly(
                 '/notes/:noteId',
                 route.note.delete
+            ).should.be.true();
+
+            // NoteHistory
+            router.get.calledWithExactly(
+                '/noteHistory/:noteId',
+                route.noteHistory.list
+            ).should.be.true();
+            router.post.calledWithExactly(
+                '/noteHistory',
+                apiMiddleware.jsonParser,
+                route.noteHistory.create
             ).should.be.true();
         });
     });

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -7,6 +7,7 @@ const model = require('../../src/model');
 
 describe('Tests for domain Note', function() {
     let noteId;
+    let noteVersion;
     let modelUser;
     let domainNote;
 
@@ -22,6 +23,7 @@ describe('Tests for domain Note', function() {
                     body: 'some body',
                 }).then(note => {
                     noteId = note.id;
+                    noteVersion = note.version;
                     domainNote = new domain.Note(note);
                 });
             });
@@ -33,14 +35,18 @@ describe('Tests for domain Note', function() {
             it('should get the id', () => {
                 domainNote.id.should.equal(noteId);
             });
+            it('should get the version', () => {
+                domainNote.version.should.equal(noteVersion);
+            });
         });
 
         describe('expose', () => {
-            it('should expose the id, subject, body and updatedAt of the note', () => {
+            it('should expose the id, subject, body, version, and updatedAt of the note', () => {
                 domainNote.expose().should.match({
                     id: noteId,
                     subject: 'some subject',
                     body: 'some body',
+                    version: noteVersion,
                     updatedAt: _.isDate,
                 });
             });
@@ -55,6 +61,7 @@ describe('Tests for domain Note', function() {
                         id: noteId,
                         subject: 'some subject',
                         body: 'new body',
+                        version: noteVersion + 1,
                         updatedAt: _.isDate,
                     });
                 });


### PR DESCRIPTION
# Note Version Tracking
## Features
- Editing a note will automatically save a version of the previous note
- If a note has been edited, the note detail page now displays dropdown list of previous versions
- Selecting a previous version from the dropdown list displays that versions body below the current version
- Note list page now lists current version of each note
- Edit and Detail pages now show current note version in breadcrumb

## Design Considerations
Versions are stored in postgreSQL via a new table named "NoteHistories." There is a one to many relationship between Note and NoteHistories. NoteHistories records are created whenever a Note is edited. This schema allows indexing via NoteId on NoteHistories for ease and speed of retrieval of old versions, as well as not creating unnecessary data when a Note has not been edited.

API routes for versions were modeled after already existing user and note routes and designed to have as minimal impact on existing code as possible. Only routes for creating and retrieving versions were created, as deletion is handled by postgres when a user deletes the parent note. This prevents a user from potentially deleting or editing history and doesn't introduce unused code.

Current version was added in the list view and to the breadcrumb for the detail and edit views so that users could easily determine which notes have multiple versions. On the note detail view a dropdown list was added to list all past versions. A dropdown was chosen to allow the user to see all past versions without the detail page becoming cluttered. Selecting a past version displays that version underneath the most recent version of a note. This method allows a user to compare past versions to the current version easily, by having them both side by side.