### PR TITLE
Bug fix that allowed users to modify subject through client js

### DIFF
--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -21,7 +21,13 @@ class Note {
     }
 
     update(note) {
-        return this._note.update(note);
+        return this._note.update({
+            body: note.body
+        }, {
+            where: {noteId: note.id},
+            returning: true,
+            plain: true
+        });
     }
 
     delete() {

--- a/test/domain/note.test.js
+++ b/test/domain/note.test.js
@@ -59,6 +59,20 @@ describe('Tests for domain Note', function() {
                     });
                 });
             });
+
+            it('should not update the subject of the note', () => {
+                return domainNote.update({
+                    body: 'newest body',
+                    subject: 'new subject'
+                }).then(() => {
+                    domainNote.expose().should.match({
+                        id: noteId,
+                        subject: 'some subject',
+                        body: 'newest body',
+                        updatedAt: _.isDate,
+                    });
+                });
+            });
         });
 
         describe('delete', () => {


### PR DESCRIPTION
Modifying app.js on the client allows a user to modify the subject of a note. If you modify the parameters of Note.update in this.updateNote (from public/src/note/edit.js) to include subject: 'edited subject' as the following:
```
        this.updateNote = function() {
            this.error = this._validate();

            if (!this.error) {
                Note.update({
                    id: this.note.id
                }, {
                    body: this.note.body,
                    subject: 'edited subject',
                }).$promise.then(() => {
                    $location.path(`/notes/${ this.note.id }`);
                }).catch(reason => {
                    this.error = 'Error occurred while updating the note.';
                });
            }
        };
```

This will update the note with 'edited subject' but any text can be entered. With the current implementation any future or present columns would also be editable regardless of the developers intent since we pass all parameters to sequelize's update at the moment. Currently we are not sanitizing any input from put or post requests and that can be very dangerous, not only for functionality but
also for security. Requests should be more atomic and sanitized before anything is done with them.

To eliminate this bug I could have reduced the parameters passed at the router, simply passing req.body.body, or the one that I chose, only pass parameters we want to update to the database in the domain class. I decided to go with the domain option, as this allows for ease of extension. If we were to add more columns to the Note table domain/note.js would already need to be updated to expose the new column, and by making domain/note more atomic the changes would be reduced to one file rather than two.